### PR TITLE
Allow for static_info_tables 6.x

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,7 +17,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '7.6.0-8.7.99',
-            'static_info_tables' => '6.5.0-6.5.99',
+            'static_info_tables' => '6.5.0-6.9.99',
             'php' => '5.6.0-0.0.0',
         ],
         'conflicts' => [],


### PR DESCRIPTION
Raising the restriction allows for installation with static_info_tables 6.8, which provides PHP 7.4.