### PR TITLE
[BUGFIX] fix typoscript-condition for TYPO3 >= V9.5

### DIFF
--- a/Configuration/PageTSconfig/Suggest.tsconfig
+++ b/Configuration/PageTSconfig/Suggest.tsconfig
@@ -1,7 +1,7 @@
 # ***************************************************************************************
 # Translate currency labels in suggestions
 # ***************************************************************************************
-[language = *fr*]
+[siteLanguage("twoLetterIsoCode") == "ja"]
 	TCEFORM.sys_language.static_lang_isocode.suggest.default.additionalSearchFields = lg_name_ja
 	TCEFORM.sys_language.static_lang_isocode.suggest.default.orderBy = lg_name_ja
 	TCEFORM.static_countries.cn_currency_uid.suggest.default.additionalSearchFields = cu_name_ja


### PR DESCRIPTION
Hi there,

an outdated typoscript-condition is throwing an error in the log for TYPO3 >= 9.5 - and it also is checking for the wrong ISO-code
` component="TYPO3.CMS.Backend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": Expression could not be parsed. - {"expression":"language = *fr*"}` 
I assume this gets logged every time a user switches between pages in the backend, filling up the log rather quickly